### PR TITLE
implement multiple board support

### DIFF
--- a/README.org
+++ b/README.org
@@ -13,8 +13,7 @@
        (aoc :repo "pkulev/aoc.el"
             :fetcher github :upgrade t)
        :custom
-       (aoc-ask-for-ids nil "Use IDs that this config sets.")
-       (aoc-private-leaderboard-id "<LEADERBOARD-ID>" "Get this from leaderboard URL.")
+       (aoc-private-leaderboard-ids '("<LEADERBOARD-ID>") "Get this from leaderboard URL.")
        (aoc-user-session-id "<SESSION-ID>" "Get this from request cookies in browser."))
    #+end_src
 
@@ -36,9 +35,9 @@
 
     Session ID that appears in cookies after authentication on https://adventofcode.com.
 
-  - =aoc-private-leaderboard-id= :: /ID for current leaderboard./
+  - =aoc-private-leaderboard-ids= :: /List of IDs for leaderboards./
 
-    Multiple boards are planned too, but now only one is supported.
+    List of Leaderboard IDs to choose from when activating the mode.
 
   - =aoc-private-leaderboard-url= :: /Private leaderboard URL template./
 
@@ -51,5 +50,3 @@
   - =aoc-private-request-interval= :: /Request interval (author asks to keep 15min interval)./
 
     Will be used for updates by timer and tracking manual updates (TODO caching).
-
-  - =aoc-ask-for-ids= :: /Whether to ask for session ID and leaderboard ID./

--- a/aoc.el
+++ b/aoc.el
@@ -62,7 +62,7 @@
   :safe t
   :type '(repeat string))
 
-(defvar-local aoc--private-leaderboard-id nil
+(defvar-local aoc-private--leaderboard-id nil
   "Private leaderboard ID.")
 
 (defcustom aoc-user-session-id
@@ -115,7 +115,7 @@ Use browser's devtools to get it from cookies."
   (declare (side-effect-free t))
   (format aoc-private-leaderboard-url
           aoc-private-leaderboard-year
-          aoc--private-leaderboard-id))
+          aoc-private--leaderboard-id))
 
 (defun aoc-private--get-curl-command ()
   (format "curl -s --cookie 'session=%s' '%s'"
@@ -284,10 +284,10 @@ Use browser's devtools to get it from cookies."
   "Show AoC private board."
   (interactive)
   (let ((buffer (get-buffer-create (aoc-private-get-buffer-name
-                                    (aoc--last-event-year)))))
+                                    aoc-private-leaderboard-year))))
     (with-current-buffer buffer
       (aoc-private-board-mode)
-      (setq aoc--private-leaderboard-id
+      (setq aoc-private--leaderboard-id
             (completing-read "Leaderboard ID: " aoc-private-leaderboard-ids))
       (aoc-private--refresh)
       (tabulated-list-print))


### PR DESCRIPTION
Changed `aoc-private-leaderboard-id` to be a list, and added a prompt for getting a board from that list upon mode activation.